### PR TITLE
Feature/close connection

### DIFF
--- a/bus/rabbitmq/bus.js
+++ b/bus/rabbitmq/bus.js
@@ -42,11 +42,7 @@ function RabbitMQBus (options) {
     self.emit('error', err);
   }).done(function (conn) {
     process.once('SIGINT', function() {
-      self.log('closing channels and connection');
-      self.channels.forEach(function (channel) {
-        channel.close();
-      });
-      conn.close();
+      self.close();
     });
 
     self.connection = conn;
@@ -186,7 +182,7 @@ RabbitMQBus.prototype.send = function send (queueName, message, options, cb) {
     cb = options;
     options = {};
   }
-  
+
   options = options || {};
 
   if (cb && ! this.confirmChannel) return cb(new Error('callbacks only supported when created with bus({ enableConfirms:true })'))
@@ -265,6 +261,16 @@ RabbitMQBus.prototype.publish = function publish (queueName, message, options, c
   this.handleOutgoing(options.queueName, message, function (queueName, message) {
     this.pubsubqueues[key].publish(message, options, cb);
   }.bind(this));
+
+};
+
+RabbitMQBus.prototype.close = function close () {
+
+  this.log('closing channels and connection');
+  this.channels.forEach(function (channel) {
+    channel.close();
+  });
+  this.connection.close();
 
 };
 

--- a/bus/rabbitmq/bus.js
+++ b/bus/rabbitmq/bus.js
@@ -41,9 +41,6 @@ function RabbitMQBus (options) {
     self.log('error connecting to rabbitmq: %s', err);
     self.emit('error', err);
   }).done(function (conn) {
-    process.once('SIGINT', function() {
-      self.close();
-    });
 
     self.connection = conn;
 


### PR DESCRIPTION
This removes the listener on SIGINT from within the module and exposes a `close()` method on the bus instead.
